### PR TITLE
chore: downgrade yfinance to unstable version

### DIFF
--- a/functions/get_stock_data/requirements.txt
+++ b/functions/get_stock_data/requirements.txt
@@ -1,4 +1,4 @@
-yfinance
+yfinance==0.1.36
 pandas
 google-cloud-bigquery>=3.12
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ black
 flake8
 isort
 pytest
-yfinance
+yfinance==0.1.36
 pandas
 google-cloud-bigquery>=3.12
 google-cloud-storage


### PR DESCRIPTION
## Summary
- pin yfinance to version 0.1.36 in requirements

## Testing
- `isort .`
- `black .`
- `flake8`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a349b923c08321971a44c40ff28e63