### PR TITLE
feat: default to YDUQ3 ticker

### DIFF
--- a/tests/test_get_stock_data.py
+++ b/tests/test_get_stock_data.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 
-def test_no_tickers(monkeypatch):
+def test_default_ticker(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "google.cloud.bigquery",
@@ -23,8 +23,14 @@ def test_no_tickers(monkeypatch):
     monkeypatch.setattr(module, "get_tickers_from_gcs", lambda: [])
     monkeypatch.setattr(
         module,
+        "download_from_b3",
+        lambda tickers, date=None: {"YDUQ3": ("2024-01-01", 10.0)},
+    )
+    monkeypatch.setattr(
+        module,
         "append_dataframe_to_bigquery",
         lambda df: None,
     )
+
     response = module.get_stock_data(None)
-    assert response == "Nenhum ticker encontrado no GCS."
+    assert response == "Success"


### PR DESCRIPTION
## Summary
- default to ticker YDUQ3 when GCS ticker file is missing or empty
- add regression test ensuring fallback to YDUQ3

## Testing
- `python -m isort tests/test_get_stock_data.py functions/get_stock_data/main.py`
- `python -m black tests/test_get_stock_data.py functions/get_stock_data/main.py`
- `python -m flake8 functions/get_stock_data/main.py tests/test_get_stock_data.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a9598b8c832189114a7c68c1b82d