### PR TITLE
Add Google Finance price scraper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,11 @@ jobs:
             --allow-unauthenticated \
             --project ingestaokraken \
             --region us-central1
+      - name: Deploy Cloud Run service
+        run: |
+          gcloud run deploy google-finance-price \
+            --source functions/google_finance_price \
+            --entry-point google_finance_price \
+            --allow-unauthenticated \
+            --project ingestaokraken \
+            --region us-central1

--- a/functions/google_finance_price/google_scraper.py
+++ b/functions/google_finance_price/google_scraper.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import re
 from typing import Optional
 
-import requests
-from bs4 import BeautifulSoup
+import requests  # type: ignore[import-untyped]
+from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 # Timeout in seconds for HTTP requests
 TIMEOUT = 10

--- a/functions/google_finance_price/main.py
+++ b/functions/google_finance_price/main.py
@@ -1,0 +1,29 @@
+"""Cloud Run function to fetch Google Finance prices."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from .google_scraper import fetch_google_finance_price
+
+
+def google_finance_price(request: Any) -> Tuple[Dict[str, float | str], int]:
+    """HTTP Cloud Run entry point returning latest price for a ticker.
+
+    Parameters
+    ----------
+    request:
+        Object with an ``args`` attribute mimicking Flask's ``Request``.
+
+    Returns
+    -------
+    tuple
+        A pair ``(body, status_code)`` suitable for Cloud Run responses.
+    """
+
+    ticker = request.args.get("ticker", "YDUQ3")
+    try:
+        price = fetch_google_finance_price(ticker)
+        return {"ticker": ticker, "price": price}, 200
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)}, 500

--- a/functions/google_finance_price/requirements.txt
+++ b/functions/google_finance_price/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework
+requests
+beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ black
 flake8
 isort
 pytest
+mypy
 pandas
 google-cloud-bigquery>=3.12
 google-cloud-storage
 pytz
 requests
+beautifulsoup4

--- a/scripts/google_scraper.py
+++ b/scripts/google_scraper.py
@@ -1,0 +1,86 @@
+"""Simple price scraper for Google Finance.
+
+This module provides utilities to fetch the latest price for a ticker
+from Google Finance. The main function ``fetch_google_finance_price``
+performs an HTTP request and parses the HTML, but a smaller
+``extract_price_from_html`` helper is exposed for easier testing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+# Timeout in seconds for HTTP requests
+TIMEOUT = 10
+
+
+def extract_price_from_html(html: str) -> float:
+    """Extract the price value from a Google Finance HTML page.
+
+    The function searches for the div containing the price using the
+    ``YMlKec`` class used by Google Finance. The returned price is a float
+    in Brazilian Real.
+
+    Parameters
+    ----------
+    html:
+        Raw HTML string from the Google Finance page.
+
+    Returns
+    -------
+    float
+        Parsed price value.
+
+    Raises
+    ------
+    ValueError
+        If the price element is not found or cannot be parsed.
+    """
+
+    soup = BeautifulSoup(html, "html.parser")
+    price_div = soup.find("div", class_="YMlKec")
+    if price_div is None:
+        raise ValueError("Could not find price element in HTML")
+
+    # Clean the price string: remove currency symbols and normalize decimal
+    # separator from comma to dot.
+    price_text = price_div.text.strip()
+    price_text = re.sub(r"[^0-9,]", "", price_text)
+    if not price_text:
+        raise ValueError("Price text is empty")
+
+    return float(price_text.replace(",", "."))
+
+
+def fetch_google_finance_price(
+    ticker: str,
+    exchange: str = "BVMF",
+    session: Optional[requests.Session] = None,
+) -> float:
+    """Fetch the latest price for ``ticker`` from Google Finance.
+
+    Parameters
+    ----------
+    ticker:
+        Stock ticker symbol, e.g. ``"YDUQ3"``.
+    exchange:
+        Exchange suffix used by Google Finance, default ``"BVMF"``.
+    session:
+        Optional ``requests.Session`` to reuse connections.
+
+    Returns
+    -------
+    float
+        Latest price for the ticker.
+    """
+
+    url = f"https://www.google.com/finance/quote/{ticker}:{exchange}"
+    sess = session or requests
+    headers = {"User-Agent": "Mozilla/5.0"}
+    response = sess.get(url, headers=headers, timeout=TIMEOUT)
+    response.raise_for_status()
+    return extract_price_from_html(response.text)

--- a/tests/test_google_finance_price_function.py
+++ b/tests/test_google_finance_price_function.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from functions.google_finance_price.main import google_finance_price
+
+
+class DummyRequest(SimpleNamespace):
+    """Minimal request object with an ``args`` attribute."""
+
+
+def test_google_finance_price_success(monkeypatch):
+    def mock_fetch(ticker: str, exchange: str = "BVMF", session=None) -> float:
+        assert ticker == "YDUQ3"
+        return 11.11
+
+    monkeypatch.setattr(
+        "functions.google_finance_price.main.fetch_google_finance_price",
+        mock_fetch,
+    )
+
+    request = DummyRequest(args={"ticker": "YDUQ3"})
+    body, status = google_finance_price(request)
+    assert status == 200
+    assert body["ticker"] == "YDUQ3"
+    assert body["price"] == pytest.approx(11.11)
+
+
+def test_google_finance_price_failure(monkeypatch):
+    def mock_fetch(ticker: str, exchange: str = "BVMF", session=None) -> float:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(
+        "functions.google_finance_price.main.fetch_google_finance_price",
+        mock_fetch,
+    )
+
+    request = DummyRequest(args={"ticker": "XYZ"})
+    body, status = google_finance_price(request)
+    assert status == 500
+    assert "error" in body

--- a/tests/test_google_scraper.py
+++ b/tests/test_google_scraper.py
@@ -1,13 +1,13 @@
 import pytest
 
-from scripts.google_scraper import extract_price_from_html
+from functions.google_finance_price import google_scraper as gf_scraper
 
 
 def test_extract_price_from_html_success():
     html = '<div class="YMlKec fxKbKc">R$ 10,50</div>'
-    assert extract_price_from_html(html) == pytest.approx(10.50)
+    assert gf_scraper.extract_price_from_html(html) == pytest.approx(10.50)
 
 
 def test_extract_price_from_html_missing():
     with pytest.raises(ValueError):
-        extract_price_from_html("<div></div>")
+        gf_scraper.extract_price_from_html("<div></div>")

--- a/tests/test_google_scraper.py
+++ b/tests/test_google_scraper.py
@@ -1,0 +1,13 @@
+import pytest
+
+from scripts.google_scraper import extract_price_from_html
+
+
+def test_extract_price_from_html_success():
+    html = '<div class="YMlKec fxKbKc">R$ 10,50</div>'
+    assert extract_price_from_html(html) == pytest.approx(10.50)
+
+
+def test_extract_price_from_html_missing():
+    with pytest.raises(ValueError):
+        extract_price_from_html("<div></div>")


### PR DESCRIPTION
## Summary
- add helper to scrape latest price from Google Finance
- cover HTML parsing logic with unit tests
- include mypy and BeautifulSoup in dependencies

## Testing
- `flake8 .`
- `pytest`
- `mypy scripts`


------
https://chatgpt.com/codex/tasks/task_e_68a3d26ecc4c8321886daf8726d1ebbf