### PR TITLE
Change logs to warning level

### DIFF
--- a/functions/google_finance_price/google_scraper.py
+++ b/functions/google_finance_price/google_scraper.py
@@ -82,16 +82,16 @@ def fetch_google_finance_price(
     """
 
     url = f"https://www.google.com/finance/quote/{ticker}:{exchange}"
-    logger.info("Fetching Google Finance URL %s for ticker %s", url, ticker)
+    logger.warning("Fetching Google Finance URL %s for ticker %s", url, ticker)
     sess = session or requests
     headers = {"User-Agent": "Mozilla/5.0"}
     response = sess.get(url, headers=headers, timeout=TIMEOUT)
-    logger.info(
+    logger.warning(
         "Received response with status %s for ticker %s",
         response.status_code,
         ticker,
     )
     response.raise_for_status()
     price = extract_price_from_html(response.text)
-    logger.info("Extracted price %.2f for ticker %s", price, ticker)
+    logger.warning("Extracted price %.2f for ticker %s", price, ticker)
     return price

--- a/functions/google_finance_price/main.py
+++ b/functions/google_finance_price/main.py
@@ -25,15 +25,16 @@ def google_finance_price(request: Any) -> Tuple[Dict[str, float | str], int]:
     """
 
     ticker = request.args.get("ticker", "YDUQ3")
-    logger.info("Received request for ticker %s", ticker)
+    logger.warning("Received request for ticker %s", ticker)
     try:
         price = fetch_google_finance_price(ticker)
-        logger.info("Returning price %.2f for ticker %s", price, ticker)
+        logger.warning("Returning price %.2f for ticker %s", price, ticker)
         return {"ticker": ticker, "price": price}, 200
     except Exception as exc:  # noqa: BLE001
-        logger.exception(
+        logger.warning(
             "Failed to fetch price for ticker %s: %s",
             ticker,
             exc,
+            exc_info=True,
         )
         return {"error": str(exc)}, 500


### PR DESCRIPTION
## Summary
- set default logging level to WARNING
- convert all logging calls to warning in Cloud Functions

## Testing
- `isort .`
- `black .`
- `flake8`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b306eeef64832192cab4401e57ecde