### PR TITLE
Use specific Google Finance price selector

### DIFF
--- a/tests/test_google_scraper.py
+++ b/tests/test_google_scraper.py
@@ -11,3 +11,9 @@ def test_extract_price_from_html_success():
 def test_extract_price_from_html_missing():
     with pytest.raises(ValueError):
         gf_scraper.extract_price_from_html("<div></div>")
+
+
+def test_extract_price_from_html_wrong_class():
+    html = '<div class="YMlKec">R$ 10,50</div>'
+    with pytest.raises(ValueError):
+        gf_scraper.extract_price_from_html(html)


### PR DESCRIPTION
## Summary
- parse price strings with helper `_parse_number`
- narrow Google Finance price lookup to `div.YMlKec.fxKbKc`
- test strict class selection for price parsing

## Testing
- `isort functions/google_finance_price/google_scraper.py tests/test_google_scraper.py`
- `black functions/google_finance_price/google_scraper.py tests/test_google_scraper.py`
- `flake8`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33365c42c8321bcab51fa2b89fbf1