### PR TITLE
Persist Google Finance price in BigQuery

### DIFF
--- a/functions/google_finance_price/main.py
+++ b/functions/google_finance_price/main.py
@@ -2,33 +2,103 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 from typing import Any, Dict, Tuple
+
+import pandas as pd  # type: ignore[import-untyped]
+from google.cloud import bigquery  # type: ignore[import-untyped]
+from pytz import timezone  # type: ignore[import-untyped]
 
 from .google_scraper import fetch_google_finance_price
 
 logger = logging.getLogger(__name__)
 
+DATASET_ID = "cotacao_intraday"
+TABELA_ID = "cotacao_bovespa"
+
+client = bigquery.Client()
+
+
+def append_dataframe_to_bigquery(df: pd.DataFrame) -> None:
+    """Append a DataFrame to the BigQuery table."""
+    try:
+        logger.warning(
+            "DataFrame received with %s rows and columns %s",
+            len(df),
+            list(df.columns),
+        )
+        if "data" in df.columns:
+            df["data"] = pd.to_datetime(df["data"]).dt.date
+        if "hora" in df.columns:
+            df["hora"] = pd.to_datetime(df["hora"], format="%H:%M").dt.time
+        if "hora_atual" in df.columns:
+            hora_atual_col = pd.to_datetime(
+                df["hora_atual"],
+                format="%H:%M",
+            )
+            df["hora_atual"] = hora_atual_col.dt.time
+        if "data_hora_atual" in df.columns:
+            df["data_hora_atual"] = pd.to_datetime(df["data_hora_atual"])
+
+        tabela_id = f"{client.project}.{DATASET_ID}.{TABELA_ID}"
+        logger.warning("Destination table: %s", tabela_id)
+        job_config = bigquery.LoadJobConfig(
+            schema=[
+                bigquery.SchemaField("ticker", "STRING"),
+                bigquery.SchemaField("data", "DATE"),
+                bigquery.SchemaField("hora", "TIME"),
+                bigquery.SchemaField("valor", "FLOAT"),
+                bigquery.SchemaField("hora_atual", "TIME"),
+                bigquery.SchemaField("data_hora_atual", "DATETIME"),
+            ],
+            write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+        )
+
+        job = client.load_table_from_dataframe(
+            df,
+            tabela_id,
+            job_config=job_config,
+        )
+        job.result()
+        logger.warning(
+            "DataFrame with %s rows inserted successfully into BigQuery.",
+            len(df),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to insert data into BigQuery: %s",
+            exc,
+            exc_info=True,
+        )
+
 
 def google_finance_price(request: Any) -> Tuple[Dict[str, float | str], int]:
-    """HTTP Cloud Run entry point returning latest price for a ticker.
-
-    Parameters
-    ----------
-    request:
-        Object with an ``args`` attribute mimicking Flask's ``Request``.
-
-    Returns
-    -------
-    tuple
-        A pair ``(body, status_code)`` suitable for Cloud Run responses.
-    """
+    """HTTP Cloud Run entry point returning latest price for a ticker."""
 
     ticker = request.args.get("ticker", "YDUQ3")
     logger.warning("Received request for ticker %s", ticker)
+    brasil_tz = timezone("America/Sao_Paulo")
+    now = datetime.datetime.now(brasil_tz)
+    data_atual = now.strftime("%Y-%m-%d")
+    hora_atual = now.strftime("%H:%M")
+    data_hora_atual = now
     try:
         price = fetch_google_finance_price(ticker)
         logger.warning("Returning price %.2f for ticker %s", price, ticker)
+        df = pd.DataFrame(
+            [
+                {
+                    "ticker": ticker,
+                    "data": data_atual,
+                    "hora": hora_atual,
+                    "valor": round(price, 2),
+                    "hora_atual": hora_atual,
+                    "data_hora_atual": data_hora_atual,
+                }
+            ]
+        )
+        append_dataframe_to_bigquery(df)
         return {"ticker": ticker, "price": price}, 200
     except Exception as exc:  # noqa: BLE001
         logger.warning(

--- a/functions/google_finance_price/requirements.txt
+++ b/functions/google_finance_price/requirements.txt
@@ -1,3 +1,6 @@
 functions-framework
 requests
 beautifulsoup4
+pandas
+google-cloud-bigquery>=3.12
+pytz

--- a/tests/test_google_finance_price_function.py
+++ b/tests/test_google_finance_price_function.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import importlib
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
-
-from functions.google_finance_price.main import google_finance_price
 
 
 class DummyRequest(SimpleNamespace):
@@ -12,32 +13,66 @@ class DummyRequest(SimpleNamespace):
 
 
 def test_google_finance_price_success(monkeypatch):
+    fake_bigquery = types.ModuleType("bigquery")
+    fake_bigquery.Client = lambda *a, **k: None
+    fake_cloud = types.ModuleType("cloud")
+    fake_cloud.bigquery = fake_bigquery
+    fake_google = types.ModuleType("google")
+    fake_google.cloud = fake_cloud
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.cloud", fake_cloud)
+    monkeypatch.setitem(sys.modules, "google.cloud.bigquery", fake_bigquery)
+    module = importlib.import_module("functions.google_finance_price.main")
+
     def mock_fetch(ticker: str, exchange: str = "BVMF", session=None) -> float:
         assert ticker == "YDUQ3"
         return 11.11
 
-    monkeypatch.setattr(
-        "functions.google_finance_price.main.fetch_google_finance_price",
-        mock_fetch,
-    )
+    monkeypatch.setattr(module, "fetch_google_finance_price", mock_fetch)
+
+    captured = {}
+
+    def mock_append(df):
+        captured["df"] = df
+
+    monkeypatch.setattr(module, "append_dataframe_to_bigquery", mock_append)
 
     request = DummyRequest(args={"ticker": "YDUQ3"})
-    body, status = google_finance_price(request)
+    body, status = module.google_finance_price(request)
     assert status == 200
     assert body["ticker"] == "YDUQ3"
     assert body["price"] == pytest.approx(11.11)
+    df = captured["df"]
+    assert list(df.columns) == [
+        "ticker",
+        "data",
+        "hora",
+        "valor",
+        "hora_atual",
+        "data_hora_atual",
+    ]
+    assert df.iloc[0]["ticker"] == "YDUQ3"
+    assert df.iloc[0]["valor"] == pytest.approx(11.11)
 
 
 def test_google_finance_price_failure(monkeypatch):
+    fake_bigquery = types.ModuleType("bigquery")
+    fake_bigquery.Client = lambda *a, **k: None
+    fake_cloud = types.ModuleType("cloud")
+    fake_cloud.bigquery = fake_bigquery
+    fake_google = types.ModuleType("google")
+    fake_google.cloud = fake_cloud
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.cloud", fake_cloud)
+    monkeypatch.setitem(sys.modules, "google.cloud.bigquery", fake_bigquery)
+    module = importlib.import_module("functions.google_finance_price.main")
+
     def mock_fetch(ticker: str, exchange: str = "BVMF", session=None) -> float:
         raise ValueError("boom")
 
-    monkeypatch.setattr(
-        "functions.google_finance_price.main.fetch_google_finance_price",
-        mock_fetch,
-    )
+    monkeypatch.setattr(module, "fetch_google_finance_price", mock_fetch)
 
     request = DummyRequest(args={"ticker": "XYZ"})
-    body, status = google_finance_price(request)
+    body, status = module.google_finance_price(request)
     assert status == 500
     assert "error" in body


### PR DESCRIPTION
## Summary
- Persist Google Finance price into BigQuery table `cotacao_intraday.cotacao_bovespa`
- Add BigQuery, pandas, and timezone dependencies for Google Finance function
- Test Google Finance function to ensure BigQuery persistence

## Testing
- `isort .`
- `black functions/google_finance_price/main.py tests/test_google_finance_price_function.py`
- `flake8`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33995df208321b655e0ea18ab0cbb