### PR TITLE
Include pyarrow for BigQuery DataFrame loading

### DIFF
--- a/functions/get_stock_data/requirements.txt
+++ b/functions/get_stock_data/requirements.txt
@@ -1,5 +1,6 @@
 pandas
 google-cloud-bigquery>=3.12
 google-cloud-storage
+pyarrow
 pytz
 requests

--- a/functions/google_finance_price/requirements.txt
+++ b/functions/google_finance_price/requirements.txt
@@ -3,4 +3,5 @@ requests
 beautifulsoup4
 pandas
 google-cloud-bigquery>=3.12
+pyarrow
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ isort
 pytest
 mypy
 pandas
+pyarrow
 google-cloud-bigquery>=3.12
 google-cloud-storage
 pytz


### PR DESCRIPTION
## Summary
- add `pyarrow` to core requirements
- ensure Google Finance and B3 functions depend on `pyarrow`

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8 .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33f5cb9388321b3bb467e07f241d3