### PR TITLE
Add db-dtypes dependency for BigQuery dataframe support

### DIFF
--- a/functions/google_finance_price/requirements.txt
+++ b/functions/google_finance_price/requirements.txt
@@ -3,5 +3,6 @@ requests
 beautifulsoup4
 pandas
 google-cloud-bigquery>=3.12
+db-dtypes
 pyarrow
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ mypy
 pandas
 pyarrow
 google-cloud-bigquery>=3.12
+db-dtypes
 google-cloud-storage
 pytz
 requests

--- a/tests/test_google_finance_price_function.py
+++ b/tests/test_google_finance_price_function.py
@@ -53,8 +53,12 @@ def test_google_finance_price_success(monkeypatch):
     assert status == 200
     assert body["tickers"] == ["YDUQ3", "PETR4"]
     assert body["processed"] == 2
-    expected_table_id = f"{FakeClient.project}.{module.DATASET_ID}.acao_bovespa"
-    expected_query = f"SELECT ticker FROM `{expected_table_id}` WHERE ativo = TRUE"
+    expected_table_id = (
+        f"{FakeClient.project}.{module.DATASET_ID}.acao_bovespa"  # noqa: E501
+    )
+    expected_query = (
+        f"SELECT ticker FROM `{expected_table_id}` WHERE ativo = TRUE"  # noqa: E501
+    )
     assert FakeClient.last_query == expected_query
     df = captured["df"]
     assert list(df.columns) == [


### PR DESCRIPTION
## Summary
- add `db-dtypes` to global and google_finance_price function requirements to satisfy BigQuery's `to_dataframe`
- tidy google_finance_price test to meet line-length linting

## Testing
- `black functions/google_finance_price/main.py`
- `black tests/test_google_finance_price_function.py`
- `isort functions/google_finance_price/main.py`
- `isort tests/test_google_finance_price_function.py`
- `flake8`
- `mypy --ignore-missing-imports functions/google_finance_price/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b365a5924483218e52409e45e7e0a8