### PR TITLE
Handle IBOV index in Google Finance scraper

### DIFF
--- a/functions/google_finance_price/google_scraper.py
+++ b/functions/google_finance_price/google_scraper.py
@@ -105,8 +105,11 @@ def fetch_google_finance_price(
     float
         Latest price for the ticker.
     """
+    if ticker.upper() == "IBOV":
+        url = "https://www.google.com/finance/quote/IBOV:INDEXBVMF"
+    else:
+        url = f"https://www.google.com/finance/quote/{ticker}:{exchange}"
 
-    url = f"https://www.google.com/finance/quote/{ticker}:{exchange}"
     logger.warning("Fetching Google Finance URL %s for ticker %s", url, ticker)
     sess = session or requests
     headers = {"User-Agent": "Mozilla/5.0"}


### PR DESCRIPTION
## Summary
- fetch IBOV index quotes from the `IBOV:INDEXBVMF` endpoint
- test IBOV URL handling in Google Finance scraper

## Testing
- `flake8`
- `mypy functions/google_finance_price/google_scraper.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7fd1794b083219b8148f9925a1dcb