### PR TITLE
feat: add indicators view and signals monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ gcloud functions deploy get_stock_data \
     --project ingestaokraken \
     --region us-central1
 ```
+
+## Monitoramento
+
+Passos para agendar a consulta diária e montar um painel no Looker Studio
+estão descritos em [docs/monitoramento.md](docs/monitoramento.md).

--- a/docs/monitoramento.md
+++ b/docs/monitoramento.md
@@ -1,0 +1,44 @@
+# Monitoramento
+
+Este guia descreve como automatizar a geração de sinais e como visualizar os resultados.
+
+## Scheduled Query diária
+
+1. Abra o console do BigQuery e navegue até **Scheduled queries**.
+2. Clique em **Create scheduled query**.
+3. Defina:
+   - **Nome**: `signals_oscilacoes`
+   - **Frequência**: `Daily`.
+   - **Hora de execução**: `17:40` no fuso `America/Sao_Paulo`.
+4. Em **Destination**, escolha `project.dataset` e marque **Write if empty**.
+5. Cole o conteúdo de [`infra/bq/signals_oscilacoes.sql`](../infra/bq/signals_oscilacoes.sql) no campo de SQL.
+6. Salve para que a consulta rode automaticamente e substitua apenas a partição do dia.
+
+## Dashboard no Looker Studio
+
+1. Acesse [Looker Studio](https://lookerstudio.google.com/) e crie um novo relatório.
+2. Selecione **BigQuery** como fonte de dados e a tabela `project.dataset.signals_oscilacoes`.
+3. Autorize o acesso e carregue os campos.
+4. Monte visualizações filtrando por `dt` e `ticker`.
+5. Salve o relatório para acompanhar os sinais diariamente.
+
+## (Opcional) Função de alertas
+
+1. Implante a Cloud Function de HTTP em `functions/alerts`:
+
+   ```bash
+   gcloud functions deploy alerts \
+       --runtime=python311 \
+       --trigger-http \
+       --allow-unauthenticated \
+       --set-secrets=BOT_TOKEN=bot-token:latest,CHAT_ID=chat-id:latest \
+       --set-env-vars=BQ_SIGNALS_TABLE=project.dataset.signals_oscilacoes
+   ```
+
+2. Teste enviando uma requisição:
+
+   ```bash
+   curl -X POST "https://REGION-PROJECT.cloudfunctions.net/alerts"
+   ```
+
+A função consulta os sinais do dia corrente, registra a contagem por ticker e envia um resumo para o Telegram caso as variáveis `BOT_TOKEN` e `CHAT_ID` estejam configuradas.

--- a/functions/alerts/main.py
+++ b/functions/alerts/main.py
@@ -1,0 +1,58 @@
+"""HTTP Cloud Function that sends daily signal alerts."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+from typing import Any, Dict, Tuple
+
+import requests  # type: ignore[import-untyped]
+from google.cloud import bigquery  # type: ignore[import-untyped]
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.WARNING))
+
+BOT_TOKEN = os.environ.get("BOT_TOKEN")
+CHAT_ID = os.environ.get("CHAT_ID")
+BQ_SIGNALS_TABLE = os.environ.get(
+    "BQ_SIGNALS_TABLE", "PROJECT_ID.dataset.signals_oscilacoes"
+)
+
+client = bigquery.Client()
+
+
+def alerts(request: Any) -> Tuple[Dict[str, Any], int]:
+    """Fetch today's signals and optionally send a Telegram alert."""
+
+    today = datetime.date.today()
+    query = f"""
+        SELECT ticker, COUNT(*) AS qtd
+        FROM `{BQ_SIGNALS_TABLE}`
+        WHERE dt = @dt
+        GROUP BY ticker
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[bigquery.ScalarQueryParameter("dt", "DATE", today)]
+    )
+    rows = list(client.query(query, job_config=job_config))
+
+    if not rows:
+        logging.warning("No signals for %s", today)
+        return {"message": f"No signals for {today.isoformat()}"}, 200
+
+    summary_lines = [f"{row['ticker']}: {row['qtd']}" for row in rows]
+    message = f"Sinais {today.isoformat()}\n" + "\n".join(summary_lines)
+    logging.warning("Resumo de sinais:\n%s", message)
+
+    if BOT_TOKEN and CHAT_ID:
+        url = f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage"
+        payload = {"chat_id": CHAT_ID, "text": message}
+        try:
+            resp = requests.post(url, json=payload, timeout=15)
+            resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001
+            logging.warning("Falha ao enviar alerta: %s", exc, exc_info=True)
+            return {"error": str(exc)}, 500
+
+    return {"rows": len(rows)}, 200

--- a/functions/alerts/requirements.txt
+++ b/functions/alerts/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-bigquery
+requests

--- a/infra/bq/mv_indicadores.sql
+++ b/infra/bq/mv_indicadores.sql
@@ -1,0 +1,54 @@
+-- Materialized view of technical indicators
+-- Replace `PROJECT_ID` and `dataset` with your BigQuery project and dataset names.
+
+CREATE OR REPLACE VIEW `PROJECT_ID.dataset.mv_indicadores` AS
+WITH ohlc AS (
+    SELECT
+        ticker,
+        DATE(data) AS dt,
+        valor AS close,
+        -- Substitute NULLs below with actual columns `high` and `low` if available
+        NULL AS high,
+        NULL AS low,
+        LAG(valor) OVER (PARTITION BY ticker ORDER BY data) AS prev_close
+    FROM `PROJECT_ID.dataset.cotacao_bovespa`
+),
+deltas AS (
+    SELECT
+        *,
+        close - LAG(close) OVER (PARTITION BY ticker ORDER BY dt) AS delta
+    FROM ohlc
+),
+ind AS (
+    SELECT
+        *,
+        AVG(close) OVER w20 AS sma20,
+        STDDEV_SAMP(close) OVER w20 AS std20,
+        AVG(close) OVER w50 AS sma50,
+        SAFE_DIVIDE(
+            AVG(close) OVER w50 - LAG(AVG(close) OVER w50) OVER (PARTITION BY ticker ORDER BY dt),
+            LAG(AVG(close) OVER w50) OVER (PARTITION BY ticker ORDER BY dt)
+        ) AS slope50_pct,
+        AVG(GREATEST(delta, 0)) OVER w14 AS avg_gain,
+        AVG(GREATEST(-delta, 0)) OVER w14 AS avg_loss,
+        CASE
+            WHEN high IS NOT NULL AND low IS NOT NULL THEN
+                AVG(GREATEST(high - low, ABS(high - prev_close), ABS(low - prev_close))) OVER w14
+        END AS atr14
+    FROM deltas
+    WINDOW
+        w20 AS (PARTITION BY ticker ORDER BY dt ROWS BETWEEN 19 PRECEDING AND CURRENT ROW),
+        w50 AS (PARTITION BY ticker ORDER BY dt ROWS BETWEEN 49 PRECEDING AND CURRENT ROW),
+        w14 AS (PARTITION BY ticker ORDER BY dt ROWS BETWEEN 13 PRECEDING AND CURRENT ROW)
+)
+SELECT
+    ticker,
+    dt,
+    close,
+    sma20,
+    sma20 + 2 * std20 AS bb_up,
+    sma20 - 2 * std20 AS bb_dn,
+    100 - 100 / (1 + avg_gain / NULLIF(avg_loss, 0)) AS rsi14,
+    atr14,
+    slope50_pct
+FROM ind;

--- a/infra/bq/signals_oscilacoes.sql
+++ b/infra/bq/signals_oscilacoes.sql
@@ -1,0 +1,53 @@
+-- Daily signals table populated from `mv_indicadores`
+-- Replace `PROJECT_ID` and `dataset` with your BigQuery project and dataset names.
+
+DECLARE run_date DATE DEFAULT DATE(CURRENT_DATE('America/Sao_Paulo'));
+
+CREATE TABLE IF NOT EXISTS `PROJECT_ID.dataset.signals_oscilacoes` (
+    dt DATE,
+    ticker STRING,
+    long_reversion BOOL,
+    short_reversion BOOL,
+    stop FLOAT64,
+    alvo FLOAT64,
+    close FLOAT64,
+    bb_dn FLOAT64,
+    bb_up FLOAT64,
+    rsi14 FLOAT64,
+    slope50_pct FLOAT64,
+    atr14 FLOAT64
+) PARTITION BY dt;
+
+DELETE FROM `PROJECT_ID.dataset.signals_oscilacoes` WHERE dt = run_date;
+
+INSERT INTO `PROJECT_ID.dataset.signals_oscilacoes`
+SELECT
+    dt,
+    ticker,
+    long_reversion,
+    short_reversion,
+    1.5 * atr14 AS stop,
+    sma20 AS alvo,
+    close,
+    bb_dn,
+    bb_up,
+    rsi14,
+    slope50_pct,
+    atr14
+FROM (
+    SELECT
+        ticker,
+        dt,
+        close,
+        sma20,
+        bb_dn,
+        bb_up,
+        rsi14,
+        atr14,
+        slope50_pct,
+        close <= bb_dn AND rsi14 < 35 AND slope50_pct < 0.001 AS long_reversion,
+        close >= bb_up AND rsi14 > 65 AND slope50_pct < 0.001 AS short_reversion
+    FROM `PROJECT_ID.dataset.mv_indicadores`
+    WHERE dt = run_date
+)
+WHERE long_reversion OR short_reversion;


### PR DESCRIPTION
## Summary
- add BigQuery view `mv_indicadores` with Bollinger, RSI and ATR placeholders
- create daily `signals_oscilacoes` query and docs for scheduled execution
- optional HTTP Cloud Function to send Telegram alerts

## Testing
- `isort functions/alerts/main.py`
- `black functions/alerts/main.py`
- `flake8`
- `mypy .`
- `pytest`
- ⚠️ `bq query --use_legacy_sql=false --dry_run < infra/bq/mv_indicadores.sql` (missing: bq)


------
https://chatgpt.com/codex/tasks/task_e_68c6ef8ddca08321a9421c904ea2d20a