### PR TITLE
feat: mover fechamento diário para tabela dedicada

### DIFF
--- a/docs/dataset_detected.md
+++ b/docs/dataset_detected.md
@@ -6,9 +6,12 @@ As consultas em `INFORMATION_SCHEMA` para as regiões `region-us-east1` e `regio
 
 ```text
 DATASET_NAME=cotacao_intraday
-PRICE_TABLE=cotacao_bovespa
-COL_DATE=data
-COL_CLOSE=valor
+PRICE_TABLE_INTRADAY=cotacao_bovespa
+PRICE_TABLE_FECHAMENTO=cotacao_fechamento_diario
+COL_DATE_INTRADAY=data
+COL_CLOSE_INTRADAY=valor
+COL_DATE_FECHAMENTO=data_pregao
+COL_CLOSE_FECHAMENTO=preco_fechamento
 COL_TICKER=ticker
 COL_HIGH=NULL
 COL_LOW=NULL
@@ -40,13 +43,21 @@ SELECT
   table_name
 FROM `ingestaokraken.cotacao_intraday`.INFORMATION_SCHEMA.TABLES;
 
--- Colunas da tabela de preços
+-- Colunas da tabela intraday
 SELECT
   column_name,
   data_type
 FROM `ingestaokraken.cotacao_intraday`.INFORMATION_SCHEMA.COLUMNS
 WHERE table_name = 'cotacao_bovespa'
 ORDER BY ordinal_position;
+
+-- Colunas da tabela de fechamento diário
+SELECT
+  column_name,
+  data_type
+FROM `ingestaokraken.cotacao_intraday`.INFORMATION_SCHEMA.COLUMNS
+WHERE table_name = 'cotacao_fechamento_diario'
+ORDER BY ordinal_position;
 ```
 
-As colunas `data`, `valor` e `ticker` foram usadas para montar as métricas diárias. O dataset não possui máximas e mínimas diárias, portanto os campos opcionais `COL_HIGH` e `COL_LOW` permanecem nulos e os cálculos que dependem deles (como o ATR) retornam `NULL` ou `0`.
+As colunas `data`, `valor` e `ticker` foram usadas para montar as métricas intraday. Para a série oficial de fechamento diário a função `get_stock_data` grava em `cotacao_fechamento_diario` utilizando os campos `data_pregao`, `preco_fechamento` e `ticker`. O dataset não possui máximas e mínimas diárias, portanto os campos opcionais `COL_HIGH` e `COL_LOW` permanecem nulos e os cálculos que dependem deles (como o ATR) retornam `NULL` ou `0`.

--- a/docs/manual_agendamentos_gcp.md
+++ b/docs/manual_agendamentos_gcp.md
@@ -1,12 +1,12 @@
 # Manual de agendamentos no GCP
 
-Este manual descreve os agendamentos necessários para manter o fluxo de ingestão, processamento e alerta do projeto **sisacao-8** operando de forma totalmente automatizada no Google Cloud Platform (GCP). Ele assume que você já implantou as funções disponíveis no repositório (`get_stock_data`, `google_finance_price` e `alerts`) e possui um dataset BigQuery com as tabelas `cotacao_intraday.cotacao_bovespa` e `signals_oscilacoes`.
+Este manual descreve os agendamentos necessários para manter o fluxo de ingestão, processamento e alerta do projeto **sisacao-8** operando de forma totalmente automatizada no Google Cloud Platform (GCP). Ele assume que você já implantou as funções disponíveis no repositório (`get_stock_data`, `google_finance_price` e `alerts`) e possui um dataset BigQuery com as tabelas `cotacao_intraday.cotacao_fechamento_diario`, `cotacao_intraday.cotacao_bovespa` e `signals_oscilacoes`.
 
 ## 1. Visão geral dos agendamentos
 
 | Agendamento | Serviço GCP | Frequência sugerida | Objetivo | Recursos envolvidos |
 |-------------|-------------|---------------------|----------|----------------------|
-| Ingestão diária oficial | Cloud Scheduler → Cloud Functions | Todo dia útil às 20:00 (America/Sao_Paulo) | Invocar a função `get_stock_data` para baixar o arquivo oficial da B3 e gravar na tabela intraday. | Cloud Function `get_stock_data`, tabela `cotacao_intraday.cotacao_bovespa` |
+| Ingestão diária oficial | Cloud Scheduler → Cloud Functions | Todo dia útil às 20:00 (America/Sao_Paulo) | Invocar a função `get_stock_data` para baixar o arquivo oficial da B3 e gravar na tabela de fechamento diário. | Cloud Function `get_stock_data`, tabela `cotacao_intraday.cotacao_fechamento_diario` |
 | Complemento intraday opcional | Cloud Scheduler → Cloud Run | A cada 30 minutos entre 10:00 e 18:00 (America/Sao_Paulo) | Acionar o serviço `google_finance_price` para buscar preços recentes no Google Finance. | Serviço HTTP `google_finance_price`, tabela `cotacao_intraday.cotacao_bovespa` |
 | Geração de sinais | Scheduled Query BigQuery | Todo dia às 17:40 (America/Sao_Paulo) | Executar `infra/bq/signals_oscilacoes.sql` para popular `signals_oscilacoes`. | BigQuery, tabela `signals_oscilacoes` |
 | Notificações | Cloud Scheduler → Cloud Functions | Todo dia às 18:00 (America/Sao_Paulo) | Enviar requisição para a função `alerts` e publicar resumo no Telegram. | Cloud Function `alerts`, tabela `signals_oscilacoes` |

--- a/infra/bq/cotacao_fechamento_diario.sql
+++ b/infra/bq/cotacao_fechamento_diario.sql
@@ -1,0 +1,18 @@
+-- Criação da tabela dedicada às cotações oficiais de fechamento diário.
+-- Ajuste o nome do projeto conforme necessário antes de executar.
+
+CREATE SCHEMA IF NOT EXISTS `ingestaokraken.cotacao_intraday`;
+
+CREATE TABLE IF NOT EXISTS `ingestaokraken.cotacao_intraday.cotacao_fechamento_diario`
+(
+  ticker STRING NOT NULL,
+  data_pregao DATE NOT NULL,
+  preco_fechamento FLOAT64 NOT NULL,
+  data_captura DATETIME NOT NULL,
+  fonte STRING NOT NULL
+)
+PARTITION BY data_pregao
+CLUSTER BY ticker
+OPTIONS (
+  description = "Cotações de fechamento diário da B3 ingeridas pelo pipeline sisacao-8"
+);

--- a/infra/bq/mv_indicadores.sql
+++ b/infra/bq/mv_indicadores.sql
@@ -2,13 +2,13 @@ CREATE OR REPLACE VIEW `ingestaokraken.cotacao_intraday.mv_indicadores` AS
 WITH base AS (
   SELECT
     ticker AS ticker,
-    CAST(data AS DATE) AS dt,
-    valor AS px_close,
+    CAST(data_pregao AS DATE) AS dt,
+    preco_fechamento AS px_close,
     /* se não houver high/low, estes ficarão NULL e o ATR vira NULL */
     NULL AS px_high,
     NULL AS px_low,
-    LAG(valor) OVER (PARTITION BY ticker ORDER BY data) AS px_prev
-  FROM `ingestaokraken.cotacao_intraday.cotacao_bovespa`
+    LAG(preco_fechamento) OVER (PARTITION BY ticker ORDER BY data_pregao) AS px_prev
+  FROM `ingestaokraken.cotacao_intraday.cotacao_fechamento_diario`
 ),
 bb AS (
   SELECT


### PR DESCRIPTION
## Summary
- direciona a função `get_stock_data` para gravar preços de fechamento na nova tabela `cotacao_intraday.cotacao_fechamento_diario`
- ajusta documentação e visão analítica para refletir a separação entre dados intraday e fechamento oficial
- adiciona o DDL do BigQuery para criar a tabela particionada de fechamento diário

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9e9db73e08321b44dd35ac9be23c8