### PR TITLE
Fix flake8 line length warning

### DIFF
--- a/functions/get_stock_data/main.py
+++ b/functions/get_stock_data/main.py
@@ -188,7 +188,9 @@ def get_stock_data(request):
             )
 
         if not rows:
-            logging.warning("Nenhum registro válido para inserir na tabela de fechamento.")
+            logging.warning(
+                "Nenhum registro válido para inserir na tabela de fechamento."
+            )
             return "No data loaded"
 
         df = pd.DataFrame(rows)


### PR DESCRIPTION
## Summary
- wrap the long warning message about missing rows to satisfy flake8 line length limits

## Testing
- flake8
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f6e40a10832190f1fab8492547a8