### PR TITLE
Carregar tickers da função get_stock_data a partir de arquivo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Coleta cotações de ações e carrega no **BigQuery** usando **Google Cloud Fun
 
 2. Crie um arquivo `.env` baseado em `config/env.example`.
 
-3. Teste localmente a Cloud Function `get_stock_data`:
+3. Ajuste a lista de tickers desejados em
+   `functions/get_stock_data/tickers.txt` (um símbolo por linha, linhas
+   iniciadas com `#` são ignoradas). A função lê esse arquivo durante a
+   execução, portanto não é necessário enviar payload com tickers.
+
+4. Teste localmente a Cloud Function `get_stock_data`:
 
    ```bash
    pip install functions-framework

--- a/docs/manual_agendamentos_gcp.md
+++ b/docs/manual_agendamentos_gcp.md
@@ -34,7 +34,8 @@ Este manual descreve os agendamentos necessários para manter o fluxo de ingest�
    - **Target type**: `HTTP`.
 3. Em **URL**, informe o endpoint da função (ex.: `https://REGION-PROJECT.cloudfunctions.net/get_stock_data`).
 4. Em **HTTP method**, selecione `POST`.
-5. Em **Body**, adicione o payload JSON esperado pela função (por exemplo, `{ "tickers": ["PETR4", "VALE3"] }`).
+5. Em **Body**, não é necessário enviar conteúdo. Os tickers monitorados são
+   lidos do arquivo `functions/get_stock_data/tickers.txt` no repositório.
 6. Em **Authentication**, selecione **Add OAuth token** e escolha a conta de serviço com permissão `Cloud Functions Invoker`.
 7. Salve o job e teste executando manualmente uma vez para validar logs e escrita no BigQuery.
 
@@ -50,8 +51,7 @@ gcloud scheduler jobs create http get-stock-data-diario \
     --http-method=POST \
     --headers="Content-Type=application/json" \
     --oidc-service-account-email=agendamentos-sisacao@PROJECT_ID.iam.gserviceaccount.com \
-    --oidc-token-audience="https://REGION-PROJECT.cloudfunctions.net/get_stock_data" \
-    --message-body='{"tickers": ["PETR4", "VALE3"]}'
+    --oidc-token-audience="https://REGION-PROJECT.cloudfunctions.net/get_stock_data"
 ```
 
 Substitua `PROJECT_ID` e `REGION` pelos valores reais. O parâmetro `--oidc-token-audience` garante que a função reconheça o token emitido pelo Cloud Scheduler.

--- a/functions/get_stock_data/tickers.txt
+++ b/functions/get_stock_data/tickers.txt
@@ -1,0 +1,4 @@
+# Lista de tickers monitorados pela função get_stock_data
+# Linhas iniciadas com # são ignoradas.
+YDUQ3
+PETR4

--- a/tests/test_get_stock_data.py
+++ b/tests/test_get_stock_data.py
@@ -1,25 +1,36 @@
 import importlib
 import os
 import sys
+import types
+
+
+def import_get_stock_module(monkeypatch):
+    fake_bigquery = types.ModuleType("bigquery")
+    fake_bigquery.Client = lambda *a, **k: None
+    fake_cloud = types.ModuleType("cloud")
+    fake_cloud.bigquery = fake_bigquery
+    fake_google = types.ModuleType("google")
+    fake_google.cloud = fake_cloud
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.cloud", fake_cloud)
+    monkeypatch.setitem(sys.modules, "google.cloud.bigquery", fake_bigquery)
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    module_name = "functions.get_stock_data.main"
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
 
 
 def test_get_stock_data_success(monkeypatch):
-    monkeypatch.setitem(
-        sys.modules,
-        "google.cloud.bigquery",
-        type("x", (), {"Client": lambda *a, **k: None}),
-    )
-    sys.path.insert(
-        0,
-        os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
-    )
-    module = importlib.import_module("functions.get_stock_data.main")
+    module = import_get_stock_module(monkeypatch)
 
     monkeypatch.setattr(
         module,
         "download_from_b3",
         lambda tickers: {"YDUQ3": ("2025-01-01", 10.0)},
     )
+    monkeypatch.setattr(module, "load_tickers_from_file", lambda path=None: ["YDUQ3"])
     monkeypatch.setattr(
         module,
         "append_dataframe_to_bigquery",
@@ -27,3 +38,11 @@ def test_get_stock_data_success(monkeypatch):
     )
     response = module.get_stock_data(None)
     assert response == "Success"
+
+
+def test_load_tickers_from_file(monkeypatch, tmp_path):
+    module = import_get_stock_module(monkeypatch)
+    tickers_file = tmp_path / "tickers.txt"
+    tickers_file.write_text("# teste\nYDUQ3\n petr4 \nYDUQ3\n", encoding="utf-8")
+    tickers = module.load_tickers_from_file(tickers_file)
+    assert tickers == ["YDUQ3", "PETR4"]


### PR DESCRIPTION
## Summary
- ler os tickers da função `get_stock_data` a partir de um arquivo local e tratar ausências
- incluir o arquivo `tickers.txt` com exemplos e atualizar README/manual de agendamento
- ajustar e ampliar os testes unitários para cobrir a nova leitura de tickers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d048ba5ed8832193b77931d444130e