### PR TITLE
Update get_stock_data to load tickers from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Coleta cotações de ações e carrega no **BigQuery** usando **Google Cloud Fun
 
 2. Crie um arquivo `.env` baseado em `config/env.example`.
 
-3. Teste localmente a Cloud Function `get_stock_data`:
+3. Ajuste a lista de tickers em `functions/get_stock_data/tickers.txt`
+   (um ticker por linha, linhas iniciadas com `#` são ignoradas). A
+   função também aceita o caminho do arquivo via variável de ambiente
+   `TICKERS_FILE`.
+
+4. Teste localmente a Cloud Function `get_stock_data`:
 
    ```bash
    pip install functions-framework

--- a/docs/guia_do_projeto.md
+++ b/docs/guia_do_projeto.md
@@ -14,6 +14,7 @@ séries de preços sem necessidade de serviços adicionais.
 - `config/`: contém o arquivo `env.example` com as variáveis mínimas necessárias para definir projeto, dataset e região no GCP.
 - `functions/get_stock_data/`: Cloud Function que baixa o arquivo oficial da B3 (`COTAHIST_D{data}.ZIP`), extrai as cotações
   solicitadas e insere os dados na tabela dedicada `cotacao_intraday.cotacao_fechamento_diario` usando o cliente do BigQuery.
+  A lista de ativos monitorados fica no arquivo `tickers.txt` (um ticker por linha, com suporte a comentários iniciados por `#`).
 - `functions/google_finance_price/`: função HTTP pensada para Cloud Run que consulta a lista de tickers ativos no BigQuery,
   busca o último preço no Google Finance via *scraping* e grava os resultados na mesma tabela de intraday.
 - `functions/alerts/`: função HTTP que consulta a tabela de sinais (`signals_oscilacoes`) e, se configurada com `BOT_TOKEN` e

--- a/docs/manual_agendamentos_gcp.md
+++ b/docs/manual_agendamentos_gcp.md
@@ -34,7 +34,7 @@ Este manual descreve os agendamentos necessários para manter o fluxo de ingest�
    - **Target type**: `HTTP`.
 3. Em **URL**, informe o endpoint da função (ex.: `https://REGION-PROJECT.cloudfunctions.net/get_stock_data`).
 4. Em **HTTP method**, selecione `POST`.
-5. Em **Body**, adicione o payload JSON esperado pela função (por exemplo, `{ "tickers": ["PETR4", "VALE3"] }`).
+5. Em **Body**, deixe vazio (a função lê os tickers de `functions/get_stock_data/tickers.txt`).
 6. Em **Authentication**, selecione **Add OAuth token** e escolha a conta de serviço com permissão `Cloud Functions Invoker`.
 7. Salve o job e teste executando manualmente uma vez para validar logs e escrita no BigQuery.
 
@@ -50,8 +50,7 @@ gcloud scheduler jobs create http get-stock-data-diario \
     --http-method=POST \
     --headers="Content-Type=application/json" \
     --oidc-service-account-email=agendamentos-sisacao@PROJECT_ID.iam.gserviceaccount.com \
-    --oidc-token-audience="https://REGION-PROJECT.cloudfunctions.net/get_stock_data" \
-    --message-body='{"tickers": ["PETR4", "VALE3"]}'
+    --oidc-token-audience="https://REGION-PROJECT.cloudfunctions.net/get_stock_data"
 ```
 
 Substitua `PROJECT_ID` e `REGION` pelos valores reais. O parâmetro `--oidc-token-audience` garante que a função reconheça o token emitido pelo Cloud Scheduler.

--- a/functions/get_stock_data/tickers.txt
+++ b/functions/get_stock_data/tickers.txt
@@ -1,0 +1,2 @@
+# Lista de tickers monitorados pela função get_stock_data.
+YDUQ3

--- a/tests/test_get_stock_data.py
+++ b/tests/test_get_stock_data.py
@@ -22,6 +22,11 @@ def test_get_stock_data_success(monkeypatch):
     )
     monkeypatch.setattr(
         module,
+        "load_tickers_from_file",
+        lambda file_path=None: ["YDUQ3"],
+    )
+    monkeypatch.setattr(
+        module,
         "append_dataframe_to_bigquery",
         lambda df: None,
     )


### PR DESCRIPTION
## Summary
- add a loader that reads tickers from a text file (or `TICKERS_FILE`) and use it in `get_stock_data`
- include the default `tickers.txt` list and document how to configure it
- refresh tests and docs to reflect the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d048ba5ed8832193b77931d444130e