### PR TITLE
Fix hardcoded GCP settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Este arquivo fornece contexto a agentes de IA (OpenAI Codex, ChatGPT, etc.) sob
 | `functions-framework` | Testes locais | Dev only. |
 
 ## 4. Variáveis de ambiente essenciais (pré‑definidas)
-- `BQ_TABLE` → `project.dataset.tabela`
+- `BQ_TABLE` → `ingestaokraken.cotacao_intraday.cotacao_fechamento_diario`
 - `GCP_PROJECT` → ID do projeto GCP
 
 ---

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ para o **Google Cloud Functions** sempre que houver push ou pull request para a
 branch `master`. Também é possível acioná-lo manualmente via *workflow_dispatch*.
 Configure o segredo `GCP_SA_KEY` (além do `BQ_TABLE` usado pela função) no
 repositório do GitHub. A função será publicada no projeto `ingestaokraken`,
-região `us-central1`.
+região `us-central1`, e gravará dados no dataset `ingestaokraken.cotacao_intraday`.
 
 O comando executado é:
 

--- a/config/env.example
+++ b/config/env.example
@@ -1,4 +1,4 @@
 # Exemplo de variáveis de ambiente
 GCP_PROJECT=ingestaokraken
-BQ_TABLE=ingestaokraken.dataset.tabela
+BQ_TABLE=ingestaokraken.cotacao_intraday.cotacao_fechamento_diario
 GCP_REGION=us-central1

--- a/docs/dataset_detected.md
+++ b/docs/dataset_detected.md
@@ -1,6 +1,6 @@
 # Dataset detectado
 
-As consultas em `INFORMATION_SCHEMA` para as regiões `region-us-east1` e `region-us` identificaram um único dataset de cotações com os campos necessários para indicadores técnicos.
+As consultas em `INFORMATION_SCHEMA` para a região `region-us-central1` identificaram um único dataset de cotações com os campos necessários para indicadores técnicos.
 
 ## Variáveis detectadas
 
@@ -22,16 +22,10 @@ COL_LOW=NULL
 ### Listagem de datasets por região
 
 ```sql
--- region-us-east1
+-- region-us-central1
 SELECT
   schema_name
-FROM `region-us-east1`.INFORMATION_SCHEMA.SCHEMATA
-WHERE catalog_name = 'ingestaokraken';
-
--- region-us
-SELECT
-  schema_name
-FROM `region-us`.INFORMATION_SCHEMA.SCHEMATA
+FROM `region-us-central1`.INFORMATION_SCHEMA.SCHEMATA
 WHERE catalog_name = 'ingestaokraken';
 ```
 

--- a/docs/guia_do_projeto.md
+++ b/docs/guia_do_projeto.md
@@ -13,10 +13,10 @@ séries de preços sem necessidade de serviços adicionais.
 
 - `config/`: contém o arquivo `env.example` com as variáveis mínimas necessárias para definir projeto, dataset e região no GCP.
 - `functions/get_stock_data/`: Cloud Function que baixa o arquivo oficial da B3 (`COTAHIST_D{data}.ZIP`), extrai as cotações
-  solicitadas e insere os dados na tabela dedicada `cotacao_intraday.cotacao_fechamento_diario` usando o cliente do BigQuery.
+  solicitadas e insere os dados na tabela dedicada `ingestaokraken.cotacao_intraday.cotacao_fechamento_diario` usando o cliente do BigQuery.
 - `functions/google_finance_price/`: função HTTP pensada para Cloud Run que consulta a lista de tickers ativos no BigQuery,
-  busca o último preço no Google Finance via *scraping* e grava os resultados na mesma tabela de intraday.
-- `functions/alerts/`: função HTTP que consulta a tabela de sinais (`signals_oscilacoes`) e, se configurada com `BOT_TOKEN` e
+  busca o último preço no Google Finance via *scraping* e grava os resultados na tabela `ingestaokraken.cotacao_intraday.cotacao_bovespa`.
+- `functions/alerts/`: função HTTP que consulta a tabela de sinais (`ingestaokraken.cotacao_intraday.signals_oscilacoes`) e, se configurada com `BOT_TOKEN` e
   `CHAT_ID`, envia um resumo para um bot do Telegram.
 - `infra/bq/`: scripts SQL de apoio, incluindo `cotacao_fechamento_diario.sql` e `signals_oscilacoes.sql`, usados nas consultas
   agendadas do BigQuery.
@@ -30,12 +30,12 @@ séries de preços sem necessidade de serviços adicionais.
 
 1. **Carga oficial diária:** a função `get_stock_data` deve ser agendada (ou acionada manualmente) após o fechamento do pregão.
    Ela baixa o arquivo de cotações diário da B3, filtra os tickers desejados e grava as informações de preço e data na tabela
-   `cotacao_intraday.cotacao_fechamento_diario`.
+   `ingestaokraken.cotacao_intraday.cotacao_fechamento_diario`.
 2. **Atualização intradiária opcional:** a função `google_finance_price` pode ser implantada como serviço HTTP para complementar
    as cotações oficiais com preços próximos ao tempo real. Ela consulta a lista de ativos marcada como `ativo = TRUE` na tabela
-   `cotacao_intraday.acao_bovespa`, busca os preços no Google Finance e insere os registros no BigQuery.
+   `ingestaokraken.cotacao_intraday.acao_bovespa`, busca os preços no Google Finance e insere os registros no BigQuery.
 3. **Derivação de sinais:** utilize a consulta `infra/bq/signals_oscilacoes.sql` como *scheduled query* diária (conforme descrito
-   em `docs/monitoramento.md`) para gerar a tabela `signals_oscilacoes` com os indicadores calculados sobre a base intraday.
+   em `docs/monitoramento.md`) para gerar a tabela `ingestaokraken.cotacao_intraday.signals_oscilacoes` com os indicadores calculados sobre a base intraday.
 4. **Alertas e monitoramento:** a função `alerts` resume os sinais do dia corrente e pode publicar mensagens no Telegram. O painel
    sugerido no Looker Studio consome a mesma tabela de sinais para acompanhamento visual.
 

--- a/docs/monitoramento.md
+++ b/docs/monitoramento.md
@@ -10,14 +10,14 @@ Este guia descreve como automatizar a geração de sinais e como visualizar os r
    - **Nome**: `signals_oscilacoes`
    - **Frequência**: `Daily`.
    - **Hora de execução**: `17:40` no fuso `America/Sao_Paulo`.
-4. Em **Destination**, escolha `project.dataset` e marque **Write if empty**.
+4. Em **Destination**, escolha `ingestaokraken.cotacao_intraday` e marque **Write if empty**.
 5. Cole o conteúdo de [`infra/bq/signals_oscilacoes.sql`](../infra/bq/signals_oscilacoes.sql) no campo de SQL.
 6. Salve para que a consulta rode automaticamente e substitua apenas a partição do dia.
 
 ## Dashboard no Looker Studio
 
 1. Acesse [Looker Studio](https://lookerstudio.google.com/) e crie um novo relatório.
-2. Selecione **BigQuery** como fonte de dados e a tabela `project.dataset.signals_oscilacoes`.
+2. Selecione **BigQuery** como fonte de dados e a tabela `ingestaokraken.cotacao_intraday.signals_oscilacoes`.
 3. Autorize o acesso e carregue os campos.
 4. Monte visualizações filtrando por `dt` e `ticker`.
 5. Salve o relatório para acompanhar os sinais diariamente.
@@ -32,13 +32,13 @@ Este guia descreve como automatizar a geração de sinais e como visualizar os r
        --trigger-http \
        --allow-unauthenticated \
        --set-secrets=BOT_TOKEN=bot-token:latest,CHAT_ID=chat-id:latest \
-       --set-env-vars=BQ_SIGNALS_TABLE=project.dataset.signals_oscilacoes
+       --set-env-vars=BQ_SIGNALS_TABLE=ingestaokraken.cotacao_intraday.signals_oscilacoes
    ```
 
 2. Teste enviando uma requisição:
 
    ```bash
-   curl -X POST "https://REGION-PROJECT.cloudfunctions.net/alerts"
+   curl -X POST "https://us-central1-ingestaokraken.cloudfunctions.net/alerts"
    ```
 
 A função consulta os sinais do dia corrente, registra a contagem por ticker e envia um resumo para o Telegram caso as variáveis `BOT_TOKEN` e `CHAT_ID` estejam configuradas.

--- a/functions/alerts/main.py
+++ b/functions/alerts/main.py
@@ -16,7 +16,8 @@ logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.WARNING))
 BOT_TOKEN = os.environ.get("BOT_TOKEN")
 CHAT_ID = os.environ.get("CHAT_ID")
 BQ_SIGNALS_TABLE = os.environ.get(
-    "BQ_SIGNALS_TABLE", "PROJECT_ID.dataset.signals_oscilacoes"
+    "BQ_SIGNALS_TABLE",
+    "ingestaokraken.cotacao_intraday.signals_oscilacoes",
 )
 
 client = bigquery.Client()


### PR DESCRIPTION
## Summary
- fix default environment examples and alert fallback to use the ingestaokraken project, us-central1 region, and cotacao_intraday dataset
- refresh documentation (README, agents guide, datasets, monitoring, scheduling, project guide) with the fixed project/region/dataset values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0497c6dd4832192cb5d26805dd936