### PR TITLE
Add TensorFlow neural network training utilities for price move detection

### DIFF
--- a/functions/pattern_detection/__init__.py
+++ b/functions/pattern_detection/__init__.py
@@ -1,0 +1,25 @@
+"""Utilities for training neural networks to detect price moves."""
+
+from .data import (
+    CLASS_NAMES,
+    WindowConfig,
+    prepare_training_data,
+    split_time_series,
+)
+from .model import (
+    ModelConfig,
+    build_mlp_model,
+    predict_actions,
+    train_model,
+)
+
+__all__ = [
+    "CLASS_NAMES",
+    "WindowConfig",
+    "prepare_training_data",
+    "split_time_series",
+    "ModelConfig",
+    "build_mlp_model",
+    "train_model",
+    "predict_actions",
+]

--- a/functions/pattern_detection/data.py
+++ b/functions/pattern_detection/data.py
@@ -1,0 +1,136 @@
+"""Dataset preparation helpers for price move classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+
+CLASS_NAMES = {0: "down", 1: "neutral", 2: "up"}
+
+
+@dataclass(frozen=True)
+class WindowConfig:
+    """Configuration for rolling window datasets."""
+
+    lookback: int = 20
+    horizon: int = 5
+    threshold: float = 0.08
+    price_column: str = "close"
+
+    def __post_init__(self) -> None:
+        if self.lookback <= 0:
+            msg = "lookback must be positive"
+            raise ValueError(msg)
+        if self.horizon <= 0:
+            msg = "horizon must be positive"
+            raise ValueError(msg)
+        if self.threshold <= 0:
+            msg = "threshold must be positive"
+            raise ValueError(msg)
+
+
+def _label_future_move(future_return: float, threshold: float) -> int:
+    """Return the class index for a future return."""
+
+    if future_return >= threshold:
+        return 2
+    if future_return <= -threshold:
+        return 0
+    return 1
+
+
+def prepare_training_data(
+    data: pd.DataFrame,
+    config: WindowConfig | None = None,
+) -> Tuple[np.ndarray, np.ndarray, pd.Index]:
+    """Create feature matrix and labels for neural network training.
+
+    Parameters
+    ----------
+    data:
+        DataFrame containing at least the configured price column. The data is
+        sorted by index before processing to ensure chronological order.
+    config:
+        Sliding window configuration. Defaults to :class:`WindowConfig` if not
+        provided.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, pd.Index]
+        Feature matrix with shape ``(n_samples, lookback)``, label vector with
+        shape ``(n_samples,)`` and the index positions associated with each
+        sample.
+    """
+
+    cfg = config or WindowConfig()
+    if cfg.price_column not in data.columns:
+        msg = f"Missing required column: {cfg.price_column}"
+        raise KeyError(msg)
+
+    series = data[[cfg.price_column]].dropna().astype(float)
+    if series.empty:
+        msg = "Input data is empty after dropping NaNs"
+        raise ValueError(msg)
+
+    series = series.sort_index()
+    prices = series[cfg.price_column]
+
+    returns = prices.pct_change()
+    returns = returns.replace([np.inf, -np.inf], np.nan)
+    returns = returns.fillna(0.0)
+    future_returns = (prices.shift(-cfg.horizon) / prices) - 1.0
+
+    start = cfg.lookback
+    end = len(prices) - cfg.horizon
+    if end <= start:
+        msg = "Not enough data for the requested configuration"
+        raise ValueError(msg)
+
+    features: List[np.ndarray] = []
+    labels: List[int] = []
+    sample_index: List[pd.Timestamp] = []
+
+    for idx in range(start, end):
+        window_series = returns.iloc[slice(idx - cfg.lookback, idx)]
+        window = window_series.to_numpy(dtype=np.float32)
+        future_value = float(future_returns.iloc[idx])
+        label_value = _label_future_move(future_value, cfg.threshold)
+        features.append(window)
+        labels.append(label_value)
+        sample_index.append(series.index[idx])
+
+    x = np.stack(features).astype(np.float32)
+    y = np.asarray(labels, dtype=np.int64)
+    index = pd.Index(sample_index)
+    return x, y, index
+
+
+def split_time_series(
+    features: np.ndarray,
+    labels: np.ndarray,
+    validation_split: float,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Split sequential data keeping chronological order."""
+
+    if not 0 < validation_split < 1:
+        msg = "validation_split must be between 0 and 1"
+        raise ValueError(msg)
+
+    total = len(features)
+    if total != len(labels):
+        msg = "features and labels must have the same length"
+        raise ValueError(msg)
+    split_index = int(total * (1 - validation_split))
+    if split_index <= 0 or split_index >= total:
+        msg = "validation_split leads to empty train or validation set"
+        raise ValueError(msg)
+
+    return (
+        features[:split_index],
+        labels[:split_index],
+        features[split_index:],
+        labels[split_index:],
+    )

--- a/functions/pattern_detection/model.py
+++ b/functions/pattern_detection/model.py
@@ -1,0 +1,148 @@
+"""TensorFlow models for price move classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+import tensorflow as tf  # type: ignore[import]
+
+from .data import CLASS_NAMES, split_time_series
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """Hyperparameters for neural network training."""
+
+    hidden_units: Sequence[int] = (64, 32)
+    dropout: float = 0.2
+    learning_rate: float = 1e-3
+    epochs: int = 30
+    batch_size: int = 32
+    validation_split: float = 0.2
+    patience: int = 5
+
+    def __post_init__(self) -> None:
+        if any(unit <= 0 for unit in self.hidden_units):
+            msg = "All hidden_units must be positive"
+            raise ValueError(msg)
+        if not 0 <= self.dropout < 1:
+            msg = "dropout must be in [0, 1)"
+            raise ValueError(msg)
+        if self.learning_rate <= 0:
+            msg = "learning_rate must be positive"
+            raise ValueError(msg)
+        if self.epochs <= 0:
+            msg = "epochs must be positive"
+            raise ValueError(msg)
+        if self.batch_size <= 0:
+            msg = "batch_size must be positive"
+            raise ValueError(msg)
+        if not 0 < self.validation_split < 1:
+            msg = "validation_split must be between 0 and 1"
+            raise ValueError(msg)
+        if self.patience < 0:
+            msg = "patience must be non-negative"
+            raise ValueError(msg)
+
+
+def build_mlp_model(
+    input_shape: Tuple[int, ...],
+    num_classes: int = 3,
+    hidden_units: Sequence[int] | None = None,
+    dropout: float = 0.2,
+    learning_rate: float = 1e-3,
+) -> tf.keras.Model:
+    """Build a dense neural network for multi-class classification."""
+
+    units = hidden_units or (64, 32)
+    inputs = tf.keras.Input(shape=input_shape)
+    x = inputs
+    for unit in units:
+        x = tf.keras.layers.Dense(unit, activation="relu")(x)
+        if dropout:
+            x = tf.keras.layers.Dropout(dropout)(x)
+    outputs = tf.keras.layers.Dense(num_classes, activation="softmax")(x)
+    model = tf.keras.Model(inputs=inputs, outputs=outputs)
+    optimizer = tf.keras.optimizers.Adam(learning_rate=learning_rate)
+    model.compile(
+        optimizer=optimizer,
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def train_model(
+    features: np.ndarray,
+    labels: np.ndarray,
+    config: ModelConfig | None = None,
+) -> Tuple[tf.keras.Model, tf.keras.callbacks.History]:
+    """Train the neural network using chronological split."""
+
+    cfg = config or ModelConfig()
+    model = build_mlp_model(
+        (features.shape[1],),
+        hidden_units=cfg.hidden_units,
+        dropout=cfg.dropout,
+        learning_rate=cfg.learning_rate,
+    )
+
+    x_train, y_train, x_val, y_val = split_time_series(
+        features, labels, cfg.validation_split
+    )
+    num_classes = len(CLASS_NAMES)
+    y_train_cat = tf.keras.utils.to_categorical(
+        y_train,
+        num_classes=num_classes,
+    )
+    y_val_cat = tf.keras.utils.to_categorical(
+        y_val,
+        num_classes=num_classes,
+    )
+
+    callbacks: Iterable[tf.keras.callbacks.Callback] = []
+    if cfg.patience:
+        callbacks = (
+            tf.keras.callbacks.EarlyStopping(
+                monitor="val_loss",
+                patience=cfg.patience,
+                restore_best_weights=True,
+            ),
+        )
+
+    history = model.fit(
+        x_train,
+        y_train_cat,
+        validation_data=(x_val, y_val_cat),
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+        callbacks=list(callbacks),
+        verbose=0,
+        shuffle=False,
+    )
+    return model, history
+
+
+def predict_actions(
+    model: tf.keras.Model,
+    features: np.ndarray,
+    threshold: float = 0.5,
+) -> np.ndarray:
+    """Convert model probabilities into trading actions."""
+
+    if not 0 < threshold < 1:
+        msg = "threshold must be between 0 and 1"
+        raise ValueError(msg)
+    probabilities = model.predict(features, verbose=0)
+    actions = []
+    for probs in probabilities:
+        down_prob, _, up_prob = probs
+        if up_prob >= threshold:
+            actions.append("buy")
+        elif down_prob >= threshold:
+            actions.append("sell")
+        else:
+            actions.append("hold")
+    return np.asarray(actions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ google-cloud-storage
 pytz
 requests
 beautifulsoup4
+tensorflow-cpu>=2.12,<3

--- a/tests/test_google_finance_price_function.py
+++ b/tests/test_google_finance_price_function.py
@@ -5,7 +5,7 @@ import sys
 import types
 from types import SimpleNamespace
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 import pytest
 
 

--- a/tests/test_pattern_detection_data.py
+++ b/tests/test_pattern_detection_data.py
@@ -1,0 +1,62 @@
+"""Tests for dataset preparation helpers."""
+
+from __future__ import annotations
+
+import pandas as pd  # type: ignore[import-untyped]
+import pytest
+
+from functions.pattern_detection import data as pattern_data
+from functions.pattern_detection.data import (
+    CLASS_NAMES,
+    WindowConfig,
+    prepare_training_data,
+    split_time_series,
+)
+
+
+def test_label_future_move_thresholds() -> None:
+    """Verify that threshold labeling follows the specification."""
+
+    assert pattern_data._label_future_move(0.1, 0.08) == 2
+    assert pattern_data._label_future_move(-0.1, 0.08) == 0
+    assert pattern_data._label_future_move(0.05, 0.08) == 1
+
+
+@pytest.mark.parametrize("lookback,horizon", [(5, 2), (10, 3)])
+def test_prepare_samples(lookback: int, horizon: int) -> None:
+    dates = pd.date_range("2024-01-01", periods=60, freq="D")
+    prices = pd.Series(range(1, 61), index=dates, name="close").astype(float)
+    df = pd.DataFrame({"close": prices})
+    config = WindowConfig(lookback=lookback, horizon=horizon, threshold=0.08)
+
+    features, labels, index = prepare_training_data(df, config)
+
+    expected_samples = len(df) - horizon - lookback
+    assert features.shape == (expected_samples, lookback)
+    assert labels.shape == (expected_samples,)
+    assert len(index) == expected_samples
+    assert set(labels).issubset(CLASS_NAMES.keys())
+
+
+def test_prepare_training_data_requires_enough_rows() -> None:
+    df = pd.DataFrame({"close": [10.0, 11.0, 12.0]})
+    config = WindowConfig(lookback=5, horizon=2)
+    with pytest.raises(ValueError):
+        prepare_training_data(df, config)
+
+
+def test_split_time_series_preserves_order() -> None:
+    rolling_mean = pd.Series(range(50)).rolling(window=3).mean().dropna()
+    features = rolling_mean.to_frame()
+    x = features.values.astype("float32")
+    y = pd.Series(range(len(x))).to_numpy()
+
+    x_train, y_train, x_val, y_val = split_time_series(x, y, 0.2)
+
+    assert x_train[-1][0] < x_val[0][0]
+    assert y_train[-1] < y_val[0]
+
+    with pytest.raises(ValueError):
+        split_time_series(x, y, 0)
+    with pytest.raises(ValueError):
+        split_time_series(x[:-1], y, 0.2)

--- a/tests/test_pattern_detection_model.py
+++ b/tests/test_pattern_detection_model.py
@@ -1,0 +1,64 @@
+"""Tests for TensorFlow model helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+
+from functions.pattern_detection.data import (
+    WindowConfig,
+    prepare_training_data,
+)
+from functions.pattern_detection.model import (
+    ModelConfig,
+    predict_actions,
+    train_model,
+)
+
+
+def _synthetic_dataset() -> tuple[np.ndarray, np.ndarray]:
+    dates = pd.date_range("2024-01-01", periods=120, freq="D")
+    base = np.linspace(10, 30, num=len(dates))
+    # Introduce oscillations to force up/down signals.
+    prices = base + np.sin(np.linspace(0, 12, num=len(dates))) * 3
+    df = pd.DataFrame({"close": prices}, index=dates)
+    config = WindowConfig(lookback=20, horizon=5, threshold=0.08)
+    features, labels, _ = prepare_training_data(df, config)
+    return features, labels
+
+
+def test_train_model_returns_history() -> None:
+    features, labels = _synthetic_dataset()
+    config = ModelConfig(
+        hidden_units=(32,),
+        dropout=0.0,
+        epochs=2,
+        batch_size=16,
+        validation_split=0.2,
+        patience=1,
+        learning_rate=1e-3,
+    )
+
+    model, history = train_model(features, labels, config)
+
+    assert "loss" in history.history
+    assert "val_loss" in history.history
+    predictions = model.predict(features[-10:], verbose=0)
+    assert predictions.shape == (10, 3)
+
+
+def test_predict_actions_thresholding() -> None:
+    features, labels = _synthetic_dataset()
+    config = ModelConfig(
+        hidden_units=(16,),
+        dropout=0.0,
+        epochs=1,
+        batch_size=32,
+        validation_split=0.3,
+        patience=0,
+        learning_rate=1e-3,
+    )
+    model, _ = train_model(features, labels, config)
+    actions = predict_actions(model, features[-5:], threshold=0.4)
+    assert actions.shape == (5,)
+    assert set(actions).issubset({"buy", "sell", "hold"})


### PR DESCRIPTION
## Summary
- add a `pattern_detection` package with helpers to build datasets and TensorFlow models that learn 8% price move patterns
- expose configuration knobs for rolling windows, training hyperparameters, and action generation
- extend the automated test suite with synthetic datasets to validate labeling, splitting, training, and signal conversion, and add TensorFlow to project dependencies

## Testing
- black --check .
- isort --check-only --profile black .
- flake8
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d45a41734883218d09e1e7ebd6b869