### PR TITLE
Handle queued Cloud Functions deployments in GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,17 +19,84 @@ jobs:
           project_id: 'ingestaokraken'
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+      - name: Wait for pending Cloud Functions operations
+        run: |
+          REGION="us-central1"
+          MAX_ATTEMPTS=20
+          SLEEP_SECONDS=30
+          PENDING="pending"
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            PENDING=$(gcloud functions operations list \
+              --region "$REGION" \
+              --filter="done=false" \
+              --format="value(name)")
+
+            if [ -z "$PENDING" ]; then
+              echo "No pending operations found before deployment."
+              break
+            fi
+
+            echo "Cloud Functions operations still running (attempt $attempt/$MAX_ATTEMPTS):"
+            echo "$PENDING"
+            echo "Waiting $SLEEP_SECONDS seconds before checking again..."
+            sleep "$SLEEP_SECONDS"
+          done
+
+          if [ -n "$PENDING" ]; then
+            echo "Timed out waiting for Cloud Functions operations to finish."
+            exit 1
+          fi
       - name: Deploy Functions
         run: |
-          gcloud functions deploy get_stock_data \
-            --runtime python311 \
-            --trigger-http \
-            --entry-point get_stock_data \
-            --source functions/get_stock_data \
-            --allow-unauthenticated \
-            --project ingestaokraken \
-            --region us-central1 \
-            --quiet
+          set +e
+
+          REGION="us-central1"
+          MAX_ATTEMPTS=5
+          RETRY_WAIT=90
+          EXIT_CODE=1
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "Starting deployment attempt $attempt/$MAX_ATTEMPTS for get_stock_data"
+            gcloud functions deploy get_stock_data \
+              --runtime python311 \
+              --trigger-http \
+              --entry-point get_stock_data \
+              --source functions/get_stock_data \
+              --allow-unauthenticated \
+              --project ingestaokraken \
+              --region "$REGION" \
+              --quiet
+            EXIT_CODE=$?
+
+            if [ "$EXIT_CODE" -eq 0 ]; then
+              echo "Deployment succeeded on attempt $attempt."
+              break
+            fi
+
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Deployment attempt $attempt failed with exit code $EXIT_CODE."
+              echo "Waiting $RETRY_WAIT seconds before retrying..."
+              sleep "$RETRY_WAIT"
+
+              echo "Checking for remaining Cloud Functions operations before retrying:"
+              PENDING=$(gcloud functions operations list \
+                --region "$REGION" \
+                --filter="done=false" \
+                --format="value(name)")
+              if [ -n "$PENDING" ]; then
+                echo "$PENDING"
+              else
+                echo "No pending operations detected."
+              fi
+            else
+              echo "Deployment failed after $MAX_ATTEMPTS attempts."
+            fi
+          done
+
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            exit "$EXIT_CODE"
+          fi
       - name: Deploy Cloud Run function
         run: |
           gcloud run deploy google-finance-price \


### PR DESCRIPTION
## Summary
- wait for in-flight Cloud Functions operations to finish before attempting a new deploy
- add retry logic around the get_stock_data deployment to reduce transient 409 conflicts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d574fd36448321ae74d4388ad4ded1