### PR TITLE
Fix deploy workflow operations listing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           PENDING="pending"
 
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            PENDING=$(gcloud functions operations list \
+            PENDING=$(gcloud beta functions operations list \
               --region "$REGION" \
               --filter="done=false" \
               --format="value(name)")
@@ -80,7 +80,7 @@ jobs:
               sleep "$RETRY_WAIT"
 
               echo "Checking for remaining Cloud Functions operations before retrying:"
-              PENDING=$(gcloud functions operations list \
+              PENDING=$(gcloud beta functions operations list \
                 --region "$REGION" \
                 --filter="done=false" \
                 --format="value(name)")


### PR DESCRIPTION
## Summary
- switch the Cloud Functions operations polling command to use gcloud beta so it is recognized by the CLI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5d5a307408321bac16420616b75dc