### PR TITLE
Fix deploy workflow to use GA Cloud Functions operations command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           PENDING="pending"
 
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            PENDING=$(gcloud beta functions operations list \
+            PENDING=$(gcloud functions operations list \
               --region "$REGION" \
               --filter="done=false" \
               --format="value(name)")
@@ -80,7 +80,7 @@ jobs:
               sleep "$RETRY_WAIT"
 
               echo "Checking for remaining Cloud Functions operations before retrying:"
-              PENDING=$(gcloud beta functions operations list \
+              PENDING=$(gcloud functions operations list \
                 --region "$REGION" \
                 --filter="done=false" \
                 --format="value(name)")


### PR DESCRIPTION
## Summary
- update deploy workflow to call the generally available `gcloud functions operations list` command
- avoid the interactive beta component installation prompt that was breaking the pipeline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e6dee9cc8321b9dfbe824c8dc8dc