### PR TITLE
Document architecture principles and scaffold app directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,4 +85,14 @@ Este arquivo fornece contexto a agentes de IA (OpenAI Codex, ChatGPT, etc.) sob
 
 ---
 
+## Princípios de arquitetura da plataforma
+
+1. **Backend Java + BigQuery**: Um serviço REST (Spring Boot ou Quarkus) fornecerá APIs para consultar sinais, parâmetros e execuções de treinamento diretamente das tabelas no BigQuery, aplicando camadas de serviço/repositório para encapsular o acesso aos dados.
+2. **Frontend web moderno**: Uma aplicação single-page (React ou Vue) consumirá as APIs expostas pelo backend para construir dashboards ricos com controles de sinais, acompanhamento de jobs de treinamento e ajustes de parâmetros.
+3. **Integração desacoplada**: Comunicação exclusiva via HTTP/JSON (ou WebSockets quando necessário), com autenticação unificada (OAuth2/OpenID) e versionamento de endpoints para facilitar evoluções independentes entre frontend e backend.
+4. **Observabilidade e governança**: Logs estruturados, métricas e rastreamento distribuído devem ser configurados desde o início para acompanhar pipelines de dados, execuções de ML e interações dos usuários.
+5. **Infraestrutura GCP**: O projeto reutiliza as variáveis `GCP_PROJECT`, `BQ_TABLE` e `GCP_REGION`, além de service accounts dedicadas para executar consultas e jobs de BigQuery com mínimo privilégio.
+
+---
+
 > As funções serão adicionadas somente após a etapa de planejamento. Por enquanto, concentre‑se em configurar ambiente, CI e documentação.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# Backend
+
+Este diretório abrigará o serviço Java (Spring Boot ou Quarkus) responsável por expor APIs REST e integrações com o BigQuery para leitura de sinais, parâmetros e controle de treinamentos de modelos.
+
+Principais componentes esperados:
+- Camada de domínio para sinais, execuções de treinamento e parametrizações.
+- Serviços e repositórios que encapsulam consultas ao BigQuery e orquestram jobs externos de ML.
+- Endpoints REST/WebSocket protegidos por OAuth2/OpenID.
+
+Mantenha a estrutura de código organizada em módulos coerentes (ex.: `api/`, `service/`, `repository/`) e configure testes automatizados desde o início.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+Este diretório reunirá a aplicação web responsável por oferecer dashboards ricos para visualização de sinais, ajustes de parâmetros e acompanhamento de execuções de treinamento.
+
+Diretrizes iniciais:
+- Utilize um framework moderno (React ou Vue) com biblioteca de componentes (Material UI, Vuetify, etc.).
+- Implemente comunicação com o backend via HTTP/JSON, adotando gerenciamento de estado global e cache de dados (React Query, RTK Query, Pinia...).
+- Priorize componentes reutilizáveis e acessíveis, com design responsivo e suporte a atualizações em tempo real quando necessário.
+
+Documente scripts de desenvolvimento, build e deploy assim que forem definidos.


### PR DESCRIPTION
## Summary
- document the backend and frontend architecture principles in AGENTS.md
- add scaffold directories for backend and frontend with README placeholders

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d74c81b2c08321a4bf4f7125ac0663