### PR TITLE
Document AWS Lightsail static IP

### DIFF
--- a/docs/backend-lightsail-setup.md
+++ b/docs/backend-lightsail-setup.md
@@ -10,6 +10,7 @@ Este guia descreve as etapas para provisionar uma instância Amazon Lightsail, i
 4. Gere ou selecione uma chave SSH para acesso administrativo.
 5. Nomeie a instância (ex.: `sisacao-backend-prod`) e conclua a criação.
 6. Anote o **Static IP** (ou configure um IP estático em **Networking → Attach static IP**) para usarmos nas automações de deploy.
+   No ambiente atual o IP atribuído é `34.194.252.70`.
 
 ## 2. Configuração de rede e firewall
 


### PR DESCRIPTION
## Summary
- document the current AWS Lightsail static IP (34.194.252.70) in the backend Lightsail setup guide

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68db1e74e150832186dd7ccfa775b618